### PR TITLE
Update and simplify the dd function

### DIFF
--- a/src/helper.php
+++ b/src/helper.php
@@ -3,8 +3,8 @@
 if (!function_exists('dd')) {
     function dd()
     {
-        $args = func_get_args();
-        call_user_func_array('dump', $args);
+        array_map('var_dump', func_get_args());
+
         die();
     }
 }


### PR DESCRIPTION
No need for call_user_func_array since we are simply var_dumping and not supplying a custom user made function. 
func_get_args can also be inlined since there is no re-use nor really a case not to shorten it this way.
